### PR TITLE
Replace pycrypto with pycryptodome

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pycrypto
+pycryptodome
 six
 future

--- a/setup.py
+++ b/setup.py
@@ -25,12 +25,8 @@ def get_packages(package):
 
 
 def get_install_requires():
-    if platform.python_implementation() == 'PyPy':
-        crypto_lib = 'pycryptodome >=3.3.1, <3.4.0'
-    else:
-        crypto_lib = 'pycrypto >=2.6.0, <2.7.0'
     return [
-        crypto_lib,
+        'pycryptodome >=3.3.1, <3.4.0',
         'six <2.0',
         'ecdsa <1.0',
         'future <1.0',

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ commands =
     py.test --cov-report term-missing --cov jose
 deps =
     future
-    pycrypto
+    pycryptodome
     ecdsa
     pytest
     pytest-cov


### PR DESCRIPTION
pycrypto has vulnerabilities pointed out at least as early as Dec 30, 2015, and the repo hasn't accept PRs since June 23, 2014.

pycryptodome is a drop-in replacement that's actively maintained and compatible with Python > 2.4. python-jose already had an option to use it for PyPy, this merely makes it the default everywhere.